### PR TITLE
[script] [burgle] Fix item_whitelist logic

### DIFF
--- a/burgle.lic
+++ b/burgle.lic
@@ -22,11 +22,14 @@ class Burgle
         { name: 'roomid', regex: /\d+/, optional: true, description: 'Override yaml setting and go to room id (#) specified.  The room should be chosen VERY carefully.'},
         { name: 'loot_type', options: %w[drop keep pawn bin], optional: true, description: 'Override yaml setting for loot. (items on item_whitelist are always kept.)' },
         { name: 'hometown', options: $HOMETOWN_LIST, optional: true, description: 'Override yaml hometown settings for bin and pawn.  If no bin or pawnshop in that hometown, loot_type will revert to drop.'},
-        { name: 'follow', options: %w[follow], optional: true, description: "Follow another player, don't actually burgle.  You must group with them first."}
+        { name: 'follow', options: %w[follow], optional: true, description: "Follow another player, don't actually burgle.  You must group with them first."},
+        { name: 'debug', regex: /debug/i, optional: true, description: 'Enable debug output' },
       ]
     ]
 
     args = parse_args(arg_definitions)
+
+    $debug_mode_burgle = UserVars.burgle_debug || args.debug || false
 
     #Ensure hometown is in sentence case if it's specified - fixes the fact parse_args is always lower case
     args.hometown = args.hometown.gsub(/\b('?[a-z])/) { $1.capitalize } if args.hometown
@@ -123,10 +126,10 @@ class Burgle
       return false
     end
     if @burgle_settings['max_search_count'] > 0
-       if /(already open|^You.+open)/ !~ bput("open my #{@loot_container}", 'already open', '^You.+open', '^You spread your arms, carefully holding your bag well away from your body', 'Please rephrase that command', 'What were you referring')
-         message("You do not have a burgle_settings:loot_container set/set to container you have.  Loot must have a place to be stored prior to exiting the house, even if dropping loot.")
-         return false
-       end
+      if /(already open|^You.+open)/ !~ bput("open my #{@loot_container}", 'already open', '^You.+open', '^You spread your arms, carefully holding your bag well away from your body', 'Please rephrase that command', 'What were you referring')
+        message("You do not have a burgle_settings:loot_container set/set to container you have.  Loot must have a place to be stored prior to exiting the house, even if dropping loot.")
+        return false
+      end
     end
 
     case @loot_type
@@ -495,7 +498,7 @@ class Burgle
   end
 
   def pawn_item(item)
-     case bput("sell my #{item}",
+    case bput("sell my #{item}",
       'You sell your',                        # success
       /shakes (his|her) head and says/,       # not worth enough (generic)
       'Relf briefly glances at your',         # not worth enough (hib - special messaging)
@@ -523,16 +526,16 @@ class Burgle
     #return if loot_type isn't one of the supported process kind
     return if @loot_type !~ /drop|pawn|bin/
     #remove whitelisted items from the loot_list
-    @loot_list.select! { | item | !(@burgle_settings['item_whitelist'].include?(item)) }
+    echo("loot_list before filtering: #{@loot_list}") if $debug_mode_burgle
+    @loot_list.select! { |loot| @burgle_settings['item_whitelist'].none?{ |keep| loot =~ /\b#{keep}\b/ } }
+    echo("loot_list after filtering: #{@loot_list}") if $debug_mode_burgle
     #return if loot_list is empty.
     return if @loot_list.empty?
 
     walk_to(@loot_room_id) unless @loot_room_id == nil
 
     @loot_list.each do |item|
-      case bput("get #{item} from my #{@loot_container}",
-                  'You get',
-                  'What were you referring to?')
+      case bput("get #{item} from my #{@loot_container}", 'You get', 'What were you referring to?')
       when /^You get/
         case @loot_type
         when 'bin'
@@ -549,7 +552,6 @@ class Burgle
   end
 
 end
-
 
 before_dying do
   #resume the previously paused scripts


### PR DESCRIPTION
## Problem
Script binned an ivory telescope when I had the word `"telescope"` in my `item_whitelist` config. womp womp.

The current filtering logic matches on exact item name but because burgled items come in many different colors and variations, I would prefer specify the keywords of the item's name so that I keep any variations. Meaning, I specify in my config to keep `"telescope"` and that keeps any colored telescope (or case). Or I could focus on just cases with `"telescope case"`.

### Changes
* Update `item_whitelist` logic to match item's whose name includes the words in the config rather than exact match.
* Updates some "off by one" whitespace because it made me twitch ;)
* Add support for `debug` flag

### Caveats

Caveat, this change doesn't handle where you want only telescopes but _not_ telescope cases. But it's better than spelling out _every_ variation of an item to keep. I'd rather keep a couple items I may decide to bin/pawn later than to miss out on items I do want to keep.

### Considerations

If the original behavior is desired, we could introduce a new setting to toggle this partial match logic. The default would be what is today -- the looted item's name must match exactly what's in your yaml in order to keep it. When this new setting is enabled then the behavior would be if the looted item's name contains the phrase that's in your yaml in order to keep it.

### Tests

I wrote a test script for the new item filtering logic. Create a .lic file in your Lich scripts folder then run it. The output will tell you if the tests pass/fail.

```ruby
require "test/unit/assertions"
include Test::Unit::Assertions

custom_require.call(%w[common])

class BurgleTest
  include DRC

  def initialize
    test_one
    test_two
    test_three
  end

  def test_one
    loot_list = [
      'blunt-tipped bolts',
      'ivory telescope',
      'slim telescope case'
    ]
    keep_list = [
      'memory orb',
      'telescope',
      'fabric',
      'blunt-tipped bolts'
    ]
    expected_list = [
      'blunt-tipped bolts',
      'ivory telescope',
      'slim telescope case'
    ]
    do_test(loot_list, keep_list, expected_list)
  end

  def test_two
    loot_list = [
      'blunt-tipped bolts',
      'ivory telescope',
      'slim telescope case'
    ]
    keep_list = [
      'memory orb',
      'telescope case',
      'fabric',
      'blunt-tipped arrows'
    ]
    expected_list = [
      'slim telescope case'
    ]
    do_test(loot_list, keep_list, expected_list)
  end

  def test_three
    loot_list = [
      'blunt-tipped bolts',
      'ivory telescope',
      'slim telescope case'
    ]
    keep_list = [
      'memory orb',
      'fabric',
    ]
    expected_list = [
    ]
    do_test(loot_list, keep_list, expected_list)
  end

  def do_test(loot_list, keep_list, expected_list)
    result_list = loot_list.select{ |loot| keep_list.any?{ |keep| loot =~ /\b#{keep}\b/ } }
    match = result_list.sort == expected_list.sort
    echo("*** TEST ***")
    echo("loot_list=#{loot_list}")
    echo("keep_list=#{loot_list}")
    echo("expected_list=#{loot_list}")
    echo("result_list=#{result_list}")
    echo("results match? #{match}")
    assert_include_same_elements(expected_list, result_list)
    echo "---------------------------"
  end

  def assert_include_same_elements(expected_list, actual_list)
    if expected_list.sort != actual_list.sort
      DRC.message("FAIL")
    else
      DRC.message("PASS")
    end
  end

end

BurgleTest.new
```
